### PR TITLE
Don't return asynchronous generator (adds support for Python 3.5)

### DIFF
--- a/pyupnp_async/upnp.py
+++ b/pyupnp_async/upnp.py
@@ -39,7 +39,7 @@ class MSResponse(object):
         return self.device
 
 
-async def msearch(search_target='upnp:rootdevice', max_wait=2, loop=None, first_only=True):
+async def msearch(search_target='upnp:rootdevice', max_wait=2, loop=None, first_only=False):
     class MSearchClientProtocol(object):
         def __init__(self, search_target, max_wait, loop):
             self.transport = None


### PR DESCRIPTION
Asynchronous Generators are not supported in Python 3.5 (Syntax Error)