### PR TITLE
Do not expect any particular namespace prefixes

### DIFF
--- a/pyupnp_async/service/wan_common_interface_config.py
+++ b/pyupnp_async/service/wan_common_interface_config.py
@@ -6,11 +6,17 @@ from ..error import UpnpKeyError
 import xmltodict
 
 
+NAMESPACES = {
+    'http://schemas.xmlsoap.org/soap/envelope/': 's',
+    'urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1': 'u',
+}
+
+
 @service('urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1')
 class WANCommonInterfaceConfig(BaseService):
     async def get_total_bytes_sent(self):
         xml = await self.request('GetTotalBytesSent')
-        data = xmltodict.parse(xml)
+        data = xmltodict.parse(xml, process_namespaces=True, namespaces=NAMESPACES)
         try:
             return data['s:Envelope']['s:Body']['u:GetTotalBytesSentResponse']['NewTotalBytesSent']
         except KeyError as e:
@@ -18,7 +24,7 @@ class WANCommonInterfaceConfig(BaseService):
 
     async def get_total_bytes_received(self):
         xml = await self.request('GetTotalBytesReceived')
-        data = xmltodict.parse(xml)
+        data = xmltodict.parse(xml, process_namespaces=True, namespaces=NAMESPACES)
         try:
             return data['s:Envelope']['s:Body']['u:GetTotalBytesReceivedResponse']['NewTotalBytesReceived']
         except KeyError as e:
@@ -26,7 +32,7 @@ class WANCommonInterfaceConfig(BaseService):
 
     async def get_total_packets_sent(self):
         xml = await self.request('GetTotalPacketsSent')
-        data = xmltodict.parse(xml)
+        data = xmltodict.parse(xml, process_namespaces=True, namespaces=NAMESPACES)
         try:
             return data['s:Envelope']['s:Body']['u:GetTotalPacketsSentResponse']['NewTotalPacketsSent']
         except KeyError as e:
@@ -34,7 +40,7 @@ class WANCommonInterfaceConfig(BaseService):
 
     async def get_total_packets_received(self):
         xml = await self.request('GetTotalPacketsReceived')
-        data = xmltodict.parse(xml)
+        data = xmltodict.parse(xml, process_namespaces=True, namespaces=NAMESPACES)
         try:
             return data['s:Envelope']['s:Body']['u:GetTotalPacketsReceivedResponse']['NewTotalPacketsReceived']
         except KeyError as e:

--- a/pyupnp_async/service/wan_ip_connection.py
+++ b/pyupnp_async/service/wan_ip_connection.py
@@ -5,12 +5,19 @@ from ..const import LIBRARY_NAME
 import xmltodict
 
 
+NAMESPACES = {
+    'http://schemas.xmlsoap.org/soap/envelope/': 's',
+    'urn:schemas-upnp-org:service:WANIPConnection:1': 'u',
+    'urn:schemas-upnp-org:service:WANIPConnection:2': 'u',
+}
+
+
 @service('urn:schemas-upnp-org:service:WANIPConnection:1')
 @service('urn:schemas-upnp-org:service:WANIPConnection:2')
 class WANIPConnectionService(BaseService):
     async def get_external_ip_address(self):
         xml = await self.request('GetExternalIPAddress')
-        data = xmltodict.parse(xml)
+        data = xmltodict.parse(xml, process_namespaces=True, namespaces=NAMESPACES)
         return data['s:Envelope']['s:Body']['u:GetExternalIPAddressResponse']['NewExternalIPAddress']
 
     async def add_port_mapping(self, int_port, ext_port, local_ip, protocol,

--- a/pyupnp_async/service/wan_ppp_connection.py
+++ b/pyupnp_async/service/wan_ppp_connection.py
@@ -5,11 +5,17 @@ from ..const import LIBRARY_NAME
 import xmltodict
 
 
+NAMESPACES = {
+    'http://schemas.xmlsoap.org/soap/envelope/': 's',
+    'urn:schemas-upnp-org:service:WANPPPConnection:1': 'u',
+}
+
+
 @service('urn:schemas-upnp-org:service:WANPPPConnection:1')
 class WANPPPConnectionService(BaseService):
     async def get_external_ip_address(self):
         xml = await self.request('GetExternalIPAddress')
-        data = xmltodict.parse(xml)
+        data = xmltodict.parse(xml, process_namespaces=True, namespaces=NAMESPACES)
         return data['s:Envelope']['s:Body']['u:GetExternalIPAddressResponse']['NewExternalIPAddress']
 
     async def add_port_mapping(self, int_port, ext_port, local_ip, protocol,


### PR DESCRIPTION
For example, `u` might not always be used for the upnp namespaces.

I came across a device today that uses `m` (not the usual `u`) for `urn:schemas-upnp-org:service:WANIPConnection:1` in its `GetExternalIPAddressResponse`.